### PR TITLE
create and manage request faster

### DIFF
--- a/app/client.go
+++ b/app/client.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/google/uuid"
@@ -154,11 +155,16 @@ func (c *client) GetAllClientRequests() []*ClientRequest {
 
 }
 
+func createClientRequestID(clientID, chals string) string {
+	return fmt.Sprintf("%s--%s", clientID, chals)
+}
+
 func (c *client) NewClientRequest(chals string) *ClientRequest {
 	c.m.Lock()
 	defer c.m.Unlock()
 
 	cc := &ClientRequest{
+		id:      createClientRequestID(c.id, chals),
 		isReady: false,
 		err:     make(chan error, 0),
 	}
@@ -175,15 +181,18 @@ func (c *client) RemoveClientRequest(chals string) {
 }
 
 type ClientRequest struct {
-	isReady    bool
-	err        chan error
-	env        Environment
-	guacCookie string
-	guacPort   uint
+	id      string
+	isReady bool
+	err     chan error
+	env     Environment
 }
 
 func (cr *ClientRequest) NewError(e error) {
 	cr.err <- e
+}
+
+func (cr *ClientRequest) ID() string {
+	return cr.id
 }
 
 func (c *client) ID() string {

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func main() {
 		return
 	}
 
-	api, err := app.New(c)
+	api, err := app.New(c, false)
 	if err != nil {
 		log.Error().Msgf("unable to create API: %s\n", err)
 		return

--- a/tests/api_test.go
+++ b/tests/api_test.go
@@ -68,7 +68,7 @@ func TestCorrectRequests(t *testing.T) {
 	}
 	config.ExercisesFile = dir + "/exercises_test.yml"
 
-	lm, err := app.New(config)
+	lm, err := app.New(config, true)
 
 	if err != nil {
 		t.Fatalf("Error Creating API : %s", err.Error())
@@ -120,7 +120,7 @@ func TestAdminRequests(t *testing.T) {
 	}
 	config.ExercisesFile = dir + "/exercises_test.yml"
 
-	lm, err := app.New(config)
+	lm, err := app.New(config, true)
 
 	if err != nil {
 		t.Fatalf("Error Creating API : %s", err.Error())
@@ -176,7 +176,7 @@ func TestClientRequests(t *testing.T) {
 	}
 	config.ExercisesFile = dir + "/exercises_test.yml"
 
-	lm, err := app.New(config)
+	lm, err := app.New(config, true)
 	if err != nil {
 		t.Fatalf("Error Creating API : %s", err.Error())
 	}
@@ -218,7 +218,7 @@ func TestAPIRequests(t *testing.T) {
 	}
 	config.ExercisesFile = dir + "/exercises_test.yml"
 
-	lm, err := app.New(config)
+	lm, err := app.New(config, true)
 	if err != nil {
 		t.Fatalf("Error Creating API : %s", err.Error())
 	}
@@ -265,7 +265,7 @@ func TestFrontendRequest(t *testing.T) {
 	}
 	config.ExercisesFile = dir + "/exercises_test.yml"
 
-	lm, err := app.New(config)
+	lm, err := app.New(config, true)
 	if err != nil {
 		t.Fatalf("Error Creating API : %s", err.Error())
 	}


### PR DESCRIPTION
- Create just a guacamole instance at the beginning
- Create guacamole user based of client ID and challenges requested
- `guacLogin` function used to create the cookie to login guacamole